### PR TITLE
update playbook, adapt to debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,9 @@ docker_insecure_registry_url: ""
 # Python packages versions
 docker_pip_packages:
   - name: docker-compose
-    version: 1.24.1
+    # last version support python2.7
+    # see https://pypi.org/project/docker-compose/1.26.2/
+    version: 1.26.2
 
 # Enable pip mirror (default to China when enabled)
 # requires a trusted repo - else need to add "--trusted-host DOMAIN"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
 #   when: not docker_bin.stat.exists and not docker_china_mirror
 
 - name: Docker | Install packages dependencies
+  when: ansible_os_family == 'RedHat'
   yum:
     name: "{{ item }}"
     state: present
@@ -45,6 +46,23 @@
 - name: Docker | Install docker on Amazon Linux
   command: amazon-linux-extras install docker -y
   when: ansible_distribution == 'Amazon'
+
+# we prefer newer version of docker
+# see https://wiki.debian.org/AptConfiguration
+- name: Docker | set apt package pin preference
+  when: ansible_os_family == 'Debian'
+  template:
+    src: apt_preference_docker.j2
+    dest: /etc/apt/preferences.d/docker
+    owner: root
+    group: root
+    mode: 0644
+
+- name: "Docker | Install docker on debian"
+  when: ansible_os_family == 'Debian'
+  package:
+    name: "docker.io"
+    state: present
 
 - name: Create /etc/docker directory
   file:

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Docker | RedHat | Install epel-release
   yum:
     name: epel-release
@@ -11,11 +12,19 @@
     state: present
   when: ansible_os_family == "RedHat"
 
-- name: Docker | Debian | Install python-pip
+# debian before 11 has python2.7
+- name: Docker | Debian | Install python-pip for debian <= 10
+  when: ansible_os_family == "Debian" and ansible_distribution_major_version|int < 11
   apt:
     name: python-pip
     state: present
-  when: ansible_os_family == "Debian"
+
+# starting from debian 11, there is only python3
+- name: Docker | Debian | Install python-pip for debian >= 11
+  when: ansible_os_family == "Debian" and ansible_distribution_major_version|int >= 11
+  apt:
+    name: python3-pip
+    state: present
 
 - name: Docker | Install Pip extensions
   pip:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -7,4 +7,3 @@
     groups: docker
     append: True
   with_items: "{{ docker_users }}"
-

--- a/templates/apt_preference_docker.j2
+++ b/templates/apt_preference_docker.j2
@@ -1,0 +1,6 @@
+# install docker from stable repo
+# as 2022.03 debian 11 is stable
+# docker version is 20.10.5
+Package: docker.io
+Pin: release a=stable
+Pin-Priority: 1000


### PR DESCRIPTION
- fix a package installation only appliable to redhat
- install python-pip for debian<=10
- install python3-pip for debian>=11, because there is only python3 on them
- pin docker.io package to stable repo as there is newer version in it
- update docker-compose 1.26.2, last version support python2.7